### PR TITLE
Clone `defaults` object to avoid property assignment

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -39,6 +39,6 @@ const parseQuery = query =>
       acc[paramKey] = parser(query[paramKey]);
     }
     return acc;
-  }, defaults);
+  }, Object.assign({}, defaults));
 
 module.exports = parseQuery;


### PR DESCRIPTION
Fixes urbica/galton#183