### PR TITLE
Fix osrm path retrieval

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ if (config.help) {
 
 try {
   // eslint-disable-next-line
-  config.osrmPath = config._[0];
+  config.osrmPath = config._.slice(-1)[0];
   fs.accessSync(config.osrmPath, fs.F_OK);
 } catch (error) {
   process.stderr.write(`${error}\n`);


### PR DESCRIPTION
getting the first positional argument may lead into wrong behaviours,
like when using PM2 to spin up an application:

```
$ pm2-runtime --auto-exit -i 4 index.js map.osrm
```

the process.argv is (if you installed node on mac osx with homebrew):

```
["/usr/local/Cellar/node@8/8.11.1/bin/node","/usr/local/lib/node_modules/pm2/lib/ProcessContainer.js","-i","4","index.js","map.osrm"]
```

and after applying minimist, config._ will look like:

```
["index.js","map.osrm"]
```

so config._[0] will point to index.js instead of map.osrm